### PR TITLE
Created an example that uses jaxrs 1

### DIFF
--- a/jaxrs1-example/pom.xml
+++ b/jaxrs1-example/pom.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>parent</artifactId>
+        <version>9.7.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>jaxrs1-example</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-jaxrs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>jsr311-api</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/jaxrs1-example/src/main/java/feign/jaxrs/examples/GitHubExample.java
+++ b/jaxrs1-example/src/main/java/feign/jaxrs/examples/GitHubExample.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jaxrs.examples;
+
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import feign.Feign;
+import feign.jaxrs.JAXRSContract;
+
+/**
+ * adapted from {@code com.example.retrofit.GitHubClient}
+ */
+public class GitHubExample {
+
+  public static void main(String... args) throws InterruptedException {
+    GitHub github = Feign.builder()
+        .contract(new JAXRSContract())
+        .target(GitHub.class, "https://api.github.com");
+
+    System.out.println("Let's fetch and print a list of the contributors to this library.");
+    List<Contributor> contributors = github.contributors("netflix", "feign");
+    for (Contributor contributor : contributors) {
+      System.out.println(contributor.login + " (" + contributor.contributions + ")");
+    }
+  }
+
+  interface GitHub {
+
+    @GET
+    @Path("/repos/{owner}/{repo}/contributors")
+    List<Contributor> contributors(@PathParam("owner") String owner,
+                                   @PathParam("repo") String repo);
+  }
+
+  static class Contributor {
+
+    String login;
+    int contributions;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <module>slf4j</module>
     <module>java8</module>
     <module>benchmark</module>
+    <module>jaxrs1-example</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
@masc3d

This shows what I think a jaxrs-1 would looks like.

If you run `GitHubExample` it will throw:

```
objc[82744]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_141.jdk/Contents/Home/bin/java (0x106e8f4c0) and /Library/Java/JavaVirtualMachines/jdk1.8.0_141.jdk/Contents/Home/jre/lib/libinstrument.dylib (0x106f1b4e0). One of the two will be used. Which one is undefined.
Exception in thread "main" java.lang.NoClassDefFoundError: javax/ws/rs/container/Suspended
	at feign.jaxrs.JAXRSContract.processAnnotationsOnParameter(JAXRSContract.java:132)
	at feign.Contract$BaseContract.parseAndValidateMetadata(Contract.java:108)
	at feign.jaxrs.JAXRSContract.parseAndValidateMetadata(JAXRSContract.java:51)
	at feign.Contract$BaseContract.parseAndValidatateMetadata(Contract.java:64)
	at feign.ReflectiveFeign$ParseHandlersByName.apply(ReflectiveFeign.java:144)
	at feign.ReflectiveFeign.newInstance(ReflectiveFeign.java:51)
	at feign.Feign$Builder.target(Feign.java:236)
	at feign.Feign$Builder.target(Feign.java:232)
	at feign.jaxrs.examples.GitHubExample.main(GitHubExample.java:33)
Caused by: java.lang.ClassNotFoundException: javax.ws.rs.container.Suspended
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 9 more
```

So, either we capture and handle this
Or, we make some settings to say this is a jaxrs 1 or 2
Or, we need to have a new `feign-jaxrs2` module

I think the code is too similiar for a new module.